### PR TITLE
Add testing matrix in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,15 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install .
     - run: python setup.py test
-    

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     author=__author__,
     author_email='jakub@roztocil.co',
     license=__licence__,
-    url='https://github.com/jakubroztocil/httpcat',
-    download_url='https://github.com/jakubroztocil/httpcat',
+    url='https://github.com/httpie/httpcat',
+    download_url='https://github.com/httpie/httpcat',
     py_modules=[
         'httpcat',
     ],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=open('README.md').read().strip(),
     version=__version__,
     author=__author__,
-    author_email='jakub@roztocil.co',
+    author_email='jakub@httpie.io',
     license=__licence__,
     url='https://github.com/httpie/httpcat',
     download_url='https://github.com/httpie/httpcat',


### PR DESCRIPTION
This updates the matrix strategy for actions to 3.7–3.11 version runs.

(Testing env compatible with 3.12+ would mean moving away from setup testing entrypoint first and perhaps also to PEP 517 installer style…)

Adds test build runs for PRs from forks, too.

Bumps actions versions.

Also updates some repo/author metadata.